### PR TITLE
PHO-187 Fix popover row overflow bug on Safari

### DIFF
--- a/docs/_includes/homepage-content.html
+++ b/docs/_includes/homepage-content.html
@@ -200,6 +200,8 @@
                 </ul>
 
             </li>
+        </ul>
+        <ul class="more-links-sitemap">
             <li><a href="http://warwick.ac.uk/news"><i class="fa fa-newspaper-o"></i>News</a>
                 <ul>
                     <li><a href="http://www2.warwick.ac.uk/newsandevents/media">Press and Media</a></li>


### PR DESCRIPTION
Splitting list items into two row containers fixes the issue.