### PR TITLE
ID-187 Fix popover row overflow bug on Safari

### DIFF
--- a/docs/_includes/homepage-content.html
+++ b/docs/_includes/homepage-content.html
@@ -200,6 +200,8 @@
                 </ul>
 
             </li>
+        </ul>
+        <ul class="more-links-sitemap">
             <li><a href="http://warwick.ac.uk/news"><i class="fa fa-newspaper-o"></i>News</a>
                 <ul>
                     <li><a href="http://www2.warwick.ac.uk/newsandevents/media">Press and Media</a></li>

--- a/docs/assets/external-homepage/external-homepage-prod.css
+++ b/docs/assets/external-homepage/external-homepage-prod.css
@@ -1119,14 +1119,18 @@ html.no-smil .id7-utility-masthead {
   clear: both;
 }
 @media (max-width: 767px) {
-  #more-links .more-links-sitemap > li:first-child {
-    padding-top: 0;
-  }
-  #more-links .more-links-sitemap > li:last-child {
-    padding-bottom: 0;
-  }
-  #more-links .more-links-sitemap > li + li {
+  #more-links .more-links-sitemap > li {
     border-top: 1px solid #777777;
+  }
+  #more-links .more-links-sitemap:first-child > li:first-child {
+    padding-top: 0;
+    border-top: none;
+  }
+  #more-links .more-links-sitemap:first-child {
+    margin-bottom: 0;
+  }
+  #more-links .more-links-sitemap + ul > li:last-child {
+    padding-bottom: 0;
   }
 }
 #more-links .more-links-sitemap > li > i,

--- a/docs/assets/external-homepage/external-homepage-prod.less
+++ b/docs/assets/external-homepage/external-homepage-prod.less
@@ -743,16 +743,21 @@ body {
     .clearfix();
 
     @media (max-width: @screen-xs-max) {
-      > li:first-child {
-        padding-top: 0;
-      }
-
-      > li:last-child {
-        padding-bottom: 0;
-      }
-
-      > li + li {
+      > li {
         border-top: 1px solid @gray-light;
+      }
+
+      &:first-child > li:first-child {
+        padding-top: 0;
+        border-top: none;
+      }
+
+      &:first-child {
+        margin-bottom: 0;
+      }
+
+      + ul > li:last-child {
+        padding-bottom: 0;
       }
     }
 


### PR DESCRIPTION
Splitting list items into two row containers fixes the issue.