### PR TITLE
ID-187 Fix popover

### DIFF
--- a/docs/assets/external-homepage/external-homepage-prod.css
+++ b/docs/assets/external-homepage/external-homepage-prod.css
@@ -1151,13 +1151,8 @@ html.no-smil .id7-utility-masthead {
 .megamenu-links .more-links-sitemap {
   margin-left: -20px;
   margin-right: -20px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-      -ms-flex-wrap: wrap;
-          flex-wrap: wrap;
+  display: table;
+  width: 100%;
 }
 .megamenu-links .more-links-sitemap a,
 .megamenu-links .more-links-sitemap a:link,
@@ -1203,11 +1198,13 @@ html.no-smil .id7-utility-masthead {
   color: #777777;
   font-size: inherit;
 }
+.megamenu-links .more-links-sitemap:first-child {
+  margin-bottom: 0;
+}
 .megamenu-links .more-links-sitemap > li {
-  -webkit-box-flex: 0;
-  -webkit-flex: 0 0 auto;
-      -ms-flex: 0 0 auto;
-          flex: 0 0 auto;
+  float: none;
+  display: table-cell;
+  height: 100%;
 }
 .megamenu-links-address {
   text-align: center;

--- a/docs/assets/external-homepage/external-homepage-prod.less
+++ b/docs/assets/external-homepage/external-homepage-prod.less
@@ -807,12 +807,18 @@ body {
       }
     }
 
-    // Flexbox it in browsers that support it to get equal-height columns
-    display: flex;
-    flex-wrap: wrap;
-    > li {
-      flex: 0 0 auto;
+    &:first-child {
+      margin-bottom: 0;
     }
+
+    display: table;
+    width: 100%;
+    > li {
+      float: none;
+      display: table-cell;
+      height: 100%;
+    }
+
   }
 }
 


### PR DESCRIPTION
Use `display: {table, table-cell}` instead of flexbox to lay out links in the popover.

Now works correctly on iOS 9. Interesting juxtaposition between brand-new operating system and ancient layout technique.