### PR TITLE
ID-228 Fall back to the usual WebSignOn popover on smaller screens

### DIFF
--- a/js/account-popover.jquery.js
+++ b/js/account-popover.jquery.js
@@ -14,7 +14,7 @@
 
   var Config = {
     Templates: {
-      Popover: function (o) { return '<div class="account-info"><iframe src="' + escapeHtml(o.useMwIframe ? o.iframelink + "?embedded" : o.legacyIframeLink) + '" scrolling="auto" frameborder="0" allowtransparency="true" seamless sandbox="allow-same-origin allow-scripts allow-top-navigation allow-forms allow-popups"></iframe></div><div class="actions"><div class="btn-group btn-group-justified"><div class="btn-group sign-out"><a href="' + escapeHtml(o.logoutlink) + '" class="btn btn-default">Sign out</a></div></div></div>'; },
+      Popover: function (o) { return '<div class="account-info"><iframe src="' + escapeHtml(o.useMwIframe ? o.iframelink + '?embedded' : o.legacyIframeLink) + '" scrolling="auto" frameborder="0" allowtransparency="true" seamless sandbox="allow-same-origin allow-scripts allow-top-navigation allow-forms allow-popups"></iframe></div><div class="actions"><div class="btn-group btn-group-justified"><div class="btn-group sign-out"><a href="' + escapeHtml(o.logoutlink) + '" class="btn btn-default">Sign out</a></div></div></div>'; },
       Action: function (o) { return '<div class="btn-group"><a href="' + escapeHtml(o.href) + '" title="' + escapeHtml(o.tooltip) + '" class="btn btn-default ' + escapeHtml(o.classes) + '">' + escapeHtml(o.title) + '</a></div>'; }
     },
     Defaults: {
@@ -26,7 +26,7 @@
       useMwIframe: true,
       maxNumberNotifications: 99,
       template: [
-        '<div class="popover $className">',
+        '<div class="popover my-warwick">',
         '<div class="arrow"></div>',
         '<div class="popover-inner">',
         '<div class="popover-content"><p></p></div>',
@@ -86,13 +86,13 @@
           $trigger.html(this.options.name + badgeHtml + ' <span class="caret"></span>');
         }
 
-        var $badge = $trigger.find(".id7-notifications-badge");
+        var $badge = $trigger.find('.id7-notifications-badge');
         $trigger.on('click', function (e) {
           e.preventDefault();
           e.stopPropagation();
           $trigger.popover('toggle');
-          $badge.find(".counter-value:not(.fa-exclamation-triangle):not(.fa-spinner)").text("0");
-          $badge.removeClass("animating");
+          $badge.find('.counter-value:not(.fa-exclamation-triangle):not(.fa-spinner)').text('0');
+          $badge.removeClass('animating');
           return false;
         });
         this.createPopover($trigger);
@@ -101,14 +101,14 @@
           var that = this;
           fetchNotificationData(this.options.notificationsApi, function(data) {
             var unreads = Math.min(data.unreads, 99);
-            $badge.find(".counter-value").removeClass('fa-spinner').removeClass('fa-spin').addClass('slideInDown').text(unreads);
+            $badge.find('.counter-value').removeClass('fa-spinner').removeClass('fa-spin').addClass('slideInDown').text(unreads);
             if (unreads > 0) {
-              $badge.fadeIn().addClass("animating");
+              $badge.fadeIn().addClass('animating');
               that.options.iframelink = that.options.iframelink + 'notifications';
               $trigger.data('bs.popover').options.content = Config.Templates.Popover(that.options);
             }
           }, function() {
-            $badge.find(".counter-value").removeClass('fa-spinner')
+            $badge.find('.counter-value').removeClass('fa-spinner')
               .removeClass('fa-spin').addClass('fa-exclamation-triangle');
             $badge.attr('title', 'There was a problem communicating with the MyWarwick notifications service');
           });
@@ -127,15 +127,15 @@
           this.options.useMwIframe = !(screenConfig.name === 'xs')
             && $(window).height() >= 700;
 
-          if ($trigger.data("bs.popover") !== undefined) {
+          if ($trigger.data('bs.popover') !== undefined) {
             $trigger.data('bs.popover').options.content = Config.Templates.Popover(this.options);
 
-            var toAdd = this.options.useMwIframe ? "my-warwick" : "account-information";
-            var $bsPopover = $trigger.data("bs.popover");
-            $bsPopover.tip().removeClass("account-information", "my-warwick").addClass(toAdd);
+            var toAdd = this.options.useMwIframe ? 'my-warwick' : 'account-information';
+            var $bsPopover = $trigger.data('bs.popover');
+            $bsPopover.tip().removeClass('account-information', 'my-warwick').addClass(toAdd);
 
             // trigger a reposition if the popover is open
-            if ($bsPopover.tip().hasClass("in")) {
+            if ($bsPopover.tip().hasClass('in')) {
               $trigger.popover('show');
             }
           }

--- a/less/notifications.less
+++ b/less/notifications.less
@@ -15,7 +15,6 @@
   animation-iteration-count: 5;
 }
 
-
 @keyframes slideInDown {
   from {
     transform: translate3d(0, -100%, 0);

--- a/less/utility-bar.less
+++ b/less/utility-bar.less
@@ -70,6 +70,10 @@
       flex-direction: column;
 
       .account-info {
+        iframe {
+          height: 100%;
+          width: 100%;
+        }
         flex: 1;
       }
 
@@ -77,27 +81,20 @@
         flex: 0;
       }
     }
+  }
 
-    .account-info {
-      iframe {
-        height: 100%;
-        width: 100%;
-      }
+  .actions {
+    .link-colour(@gray-dark);
+
+    a:hover, a:focus {
+      text-decoration: none;
     }
 
-    .actions {
-      .link-colour(@gray-dark);
+    background: @id7-account-popover-actions-bg;
+    border-top: 1px solid @id7-account-popover-actions-border;
 
-      a:hover, a:focus {
-        text-decoration: none;
-      }
-
-      background: @id7-account-popover-actions-bg;
-      border-top: 1px solid @id7-account-popover-actions-border;
-
-      .btn-group-justified {
-        border-spacing: (@line-height-computed / 2);
-      }
+    .btn-group-justified {
+      border-spacing: (@line-height-computed / 2);
     }
   }
 
@@ -108,5 +105,14 @@
     .popover-content .account-info {
       padding: 15px 19px;
     }
+
+    .popover-content {
+      .account-info {
+        iframe {
+          height: 80px;
+        }
+      }
+    }
+
   }
 }

--- a/less/utility-bar.less
+++ b/less/utility-bar.less
@@ -49,13 +49,16 @@
     }
   }
 
-  .popover.account-information {
-    text-shadow: none;
-
-    max-width: 100%;
-    width: @id7-account-popover-width;
-    height: @id7-account-popover-height;
+  .popover.my-warwick {
+    width: @id7-mw-popover-width;
+    max-height: @id7-mw-popover-height;
+    height: 80vh;
     padding: 0;
+  }
+
+  .popover.account-information, .popover.my-warwick {
+    text-shadow: none;
+    max-width: 100%;
 
     .popover-inner, .popover-content {
       height: 100%;
@@ -95,6 +98,15 @@
       .btn-group-justified {
         border-spacing: (@line-height-computed / 2);
       }
+    }
+  }
+
+  .popover.account-information {
+    width: @id7-account-popover-width;
+    height: auto;
+
+    .popover-content .account-info {
+      padding: 15px 19px;
     }
   }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -27,7 +27,7 @@
 @id7-subtle-line-colour: #ababab;
 
 @id7-account-popover-width: 320px;
-@id7-mw-popover-width: 375px;
+@id7-mw-popover-width: 380px;
 @id7-mw-popover-height: 640px;
 @id7-account-popover-actions-bg: #f7f7f7;
 @id7-account-popover-actions-border: #ebebeb;

--- a/less/variables.less
+++ b/less/variables.less
@@ -26,8 +26,9 @@
 
 @id7-subtle-line-colour: #ababab;
 
-@id7-account-popover-width: 375px;
-@id7-account-popover-height: 640px;
+@id7-account-popover-width: 320px;
+@id7-mw-popover-width: 375px;
+@id7-mw-popover-height: 640px;
 @id7-account-popover-actions-bg: #f7f7f7;
 @id7-account-popover-actions-border: #ebebeb;
 


### PR DESCRIPTION
Things learnt:

* When we call `.popover(opts)` on an element, `.data("bs.popover")` becomes available immediately. We can call `.tip()` on this to manipulate the classes on the popover element. This is a lot more reliable than modifying the template retroactively, or trying to destrory and recreate the popover.
* MWE: https://codepen.io/anon/pen/qjXNGZ?editors=1111

This should also fix the "append 0 when can't connect to MyWarwick" issue.