### PR TITLE
Fix up the feature flag to be more lenient and enable it by default

### DIFF
--- a/docs/_includes/components/utility-bar.html
+++ b/docs/_includes/components/utility-bar.html
@@ -8,7 +8,7 @@
     <li><a href="#">App link 1</a></li>
     <li><a href="#">App link 2</a></li>
     <li>
-      <a href="http://logout.link.goes.here" data-toggle="id7:account-popover" data-loginlink="http://login.link.goes.here" data-name="Your name">Sign out</a>
+      <a href="http://logout.link.goes.here" data-mw-functionality="true" data-toggle="id7:account-popover" data-loginlink="http://login.link.goes.here" data-name="Your name">Sign out</a>
     </li>
   </ul>
 </nav>

--- a/docs/_includes/utility-bar.html
+++ b/docs/_includes/utility-bar.html
@@ -3,7 +3,7 @@
         <li><a href="#">Text only</a></li>
         <li><a href="#">Notify</a></li>
         <li>
-            <a href="http://logout.link.goes.here" data-toggle="id7:account-popover" data-loginlink="http://login.link.goes.here" data-name="Your name">Sign out</a>
+            <a href="http://logout.link.goes.here" data-mw-functionality="true" data-toggle="id7:account-popover" data-loginlink="http://login.link.goes.here" data-name="Your name">Sign out</a>
         </li>
     </ul>
 </nav>

--- a/docs/_layouts/external-homepage-prod.html
+++ b/docs/_layouts/external-homepage-prod.html
@@ -22,7 +22,7 @@
                   <li><a href="#">Text only</a></li>
                   <li><a href="#">Notify</a></li>
                   <li>
-                      <a href="http://logout.link.goes.here" data-toggle="id7:account-popover" data-loginlink="http://login.link.goes.here" data-name="Your Name">Sign out</a>
+                      <a href="http://logout.link.goes.here" data-mw-functionality="true" data-toggle="id7:account-popover" data-loginlink="http://login.link.goes.here" data-name="Your Name">Sign out</a>
                   </li>
               </ul>
           </nav>

--- a/js/account-popover.jquery.js
+++ b/js/account-popover.jquery.js
@@ -80,7 +80,7 @@
         $trigger.popover(opts);
       },
       featureFlagTest: function featureFlagTest($trigger) {
-        return $trigger.data('mw-functionality') === 'true';
+        return $trigger.data('mw-functionality');
       },
       wireEventHandlers: function wireEventHandlers() {
         var $trigger = this.$trigger;


### PR DESCRIPTION
It appears jQuery's data function converts DOM attributes to e.g.
booleans if they match true/false. The original test assumed the value
would always be a string, and used the strict === comparison operator.

Since this assumption was wrong, it made it impossible to actually enable
the MW feature after PR #45 was merged.

~~TODO: Remove diff of generated files which seem to be in the repo.~~