### PR TITLE
ID-246 Handle reflow event being listened for after it's already been fired

### DIFF
--- a/js/account-popover.jquery.js
+++ b/js/account-popover.jquery.js
@@ -140,7 +140,7 @@
         });
 
         // Smaller screens get the old popover
-        $(window).on('id7:reflow', $.proxy(function (e, screenConfig) {
+        var onReflow = $.proxy(function (e, screenConfig) {
           this.options.useMwIframe = screenConfig.name !== 'xs'
             && $(window).height() >= 600 && this.isMwFeatureAvailable();
 
@@ -160,7 +160,16 @@
               $trigger.next('.popover').removeClass('loading');
             }
           }
-        }, this));
+        }, this);
+
+        $(window).on('id7:reflow', onReflow);
+
+        // If the document is already loaded this won't be fired as expected, so fire it manually
+        if (document.readyState === 'complete' && typeof $(window).data('id7.reflow') !== 'undefined') {
+          // Call reflow immediately
+          var screenConfig = $(window).data('id7.reflow')._screenConfig();
+          onReflow({}, screenConfig);
+        }
       },
       onMessage: function onMessage(messageType, data) {
         var $popover = this.$trigger.next('.popover');

--- a/js/navigation.jquery.js
+++ b/js/navigation.jquery.js
@@ -216,7 +216,7 @@
         this.$container.find('.navbar').each(function () {
           var $navbar = $(this);
 
-          if (screenConfig.name == 'xs') {
+          if (screenConfig.name === 'xs') {
             // Require a click (tap) to open dropdowns
             $navbar.find('.dropdown-toggle')
               .attr('data-toggle', 'dropdown')
@@ -275,7 +275,7 @@
       },
 
       wireEventHandlers: function wireEventHandlers() {
-        if (document.readyState == 'complete') {
+        if (document.readyState === 'complete') {
           if (this.options.fixedNav) this.affixNav();
           if (this.options.fixedHeader) this.affixHeader();
           this.updateWrappedState();
@@ -287,13 +287,22 @@
           }, this));
         }
 
-        $(window).on('id7:reflow', $.proxy(function (e, screenConfig) {
+        var onReflow = $.proxy(function (e, screenConfig) {
           if (this.options.fitToWidth) this.fitToWidth(screenConfig);
           if (this.options.fixedHeader) this.markHeaderFixedPosition();
           if (this.options.fixedNav) this.markFixedPosition();
           this.updateWrappedState();
           this.updateDropdownBehaviour(screenConfig);
-        }, this));
+        }, this);
+
+        $(window).on('id7:reflow', onReflow);
+
+        // If the document is already loaded this won't be fired as expected, so fire it manually
+        if (document.readyState === 'complete' && typeof $(window).data('id7.reflow') !== 'undefined') {
+          // Call reflow immediately
+          var screenConfig = $(window).data('id7.reflow')._screenConfig();
+          onReflow({}, screenConfig);
+        }
 
         this.$container.on('click', '.nav > li', function (e) {
           var $targetLink = $(e.target).closest('a');

--- a/js/reflow-event.jquery.js
+++ b/js/reflow-event.jquery.js
@@ -66,7 +66,7 @@
         $(window).on('resize.id7.reflow.onScreenResize', $.proxy(this.onScreenResize, this));
 
         // ID-30 on load (i.e. after fonts have loaded) run this, forcing a resize
-        if (document.readyState == 'complete') {
+        if (document.readyState === 'complete') {
           this.reflow();
         } else {
           $(window).on('load', $.proxy(this.reflow, this));


### PR DESCRIPTION
Open to suggestion on whether this is the right fix to make, or whether we should do something to defer the call of `this.reflow();` on `reflow-event.jquery.js:70` to give time for the listeners to be bound.