### PR TITLE
Make a note of required Ruby version until fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Documentation, included in this repo in the root directory, is built with [Jekyl
 
 ### Running sample site locally
 
-1. Install Ruby and run `gem install bundler`.
+1. Install Ruby ([< 2.4](https://github.com/brianmario/yajl-ruby/issues/170)) and run `gem install bundler`.
 1. Install node.js.
 1. In the root `/id7` directory:
     1. Run `bundle install` to install dependent gems.


### PR DESCRIPTION
It took me a while to work this out so I could get `grunt serve` to work as it usually does. I think Ubuntu updated the Ruby version in the repos recently