### PR TITLE
Add @id7-utility-bar-bg for overriding utility bar background colour

### DIFF
--- a/less/mixins.less
+++ b/less/mixins.less
@@ -9,3 +9,4 @@
 @import 'mixins/svg-background-with-fallback.less';
 @import 'mixins/bootstrap-fixes-button-variant.less';
 @import 'mixins/bootstrap-fixes-form-control-validation.less';
+@import 'mixins/utility-bar-bg.less';

--- a/less/mixins/utility-bar-bg.less
+++ b/less/mixins/utility-bar-bg.less
@@ -1,0 +1,14 @@
+.utility-bar-bg(@id7-utility-bar-bg) {
+  nav.id7-utility-bar {
+    background: @id7-utility-bar-bg !important;
+
+    .linkColours () when (lightness(@id7-utility-bar-bg) > 50%) {
+      .link-colour(@gray);
+
+      > ul li .id7-notifications-badge .counter-value {
+        color: white;
+      }
+    }
+    .linkColours();
+  }
+}

--- a/less/utility-bar.less
+++ b/less/utility-bar.less
@@ -10,10 +10,13 @@
 
   > ul {
     .pull-right();
-    .horizontal-utility-links(0.4em, @gray-lighter);
   }
 
   .link-colour(white);
+
+  > ul {
+    .horizontal-utility-links(0.4em, @gray-lighter);
+  }
 
   .caret { margin-left: 5px; }
 


### PR DESCRIPTION
E.g. Warwick conferences site could use this, and get the appropriate contrast on the links and notifications badge for free.

Default:
![image](https://user-images.githubusercontent.com/2552726/48854197-33da4a80-eda9-11e8-978d-dc4d2974b113.png)

White:
![image](https://user-images.githubusercontent.com/2552726/48854360-a21f0d00-eda9-11e8-8bf4-12f3cca209c5.png)
