### PR TITLE
ID-253 Set crossorigin attribute, drop protocol relative URL

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -28,7 +28,7 @@
   {% endif %}
 </title>
 
-<link href="//fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic&amp;subset=latin,latin-ext" rel="stylesheet" type="text/css">
+<link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic&amp;subset=latin,latin-ext" rel="stylesheet" type="text/css" crossorigin="anonymous">
 
 <link href="/dist/css/id7.css" rel="stylesheet" type="text/css">
 <link href="/dist/css/id7-default-theme.css" rel="stylesheet" type="text/css">

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,8 +12,8 @@
   <title>Your page title</title>
 
   <!-- Lato web font -->
-  <link href="//fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic&amp;subset=latin,latin-ext"
-      rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic&amp;subset=latin,latin-ext"
+      rel="stylesheet" type="text/css" crossorigin="anonymous">
 
   <!-- ID7 -->
   <link href="css/id7.min.css" rel="stylesheet">


### PR DESCRIPTION
I've tested this by:

* Visiting `https://fonts.googleapis.com`.
* Running `document.cookie="MyCookie=123"`.
* Verifying that, without the `crossorigin` attribute, the cookie is sent along with the request to fetch the font CSS.
* Verifying that, with the attribute, the cookie is *not* sent.

I've also taken the chance to drop use of protocol relative URLs for the external font. They might've made sense a while back, but we should just prefer to always fetch securely now IMO (especially since `fonts.googleapis.com` isn't HSTS preload'd). 