### PR TITLE
ID-296 Include more of the standard fa rules.

### DIFF
--- a/docs/examples/hyphens/index.html
+++ b/docs/examples/hyphens/index.html
@@ -159,7 +159,7 @@ slug: examples/hyphens
         <p><a href="news/">More news stories »</a></p>
     </section>
     <aside class="column-2">
-        <p>Note <a class="new-window-link" href="http://caniuse.com/#feat=css-hyphens" target="_blank">browser support</a>:</p>
+        <p>Note <a href="http://caniuse.com/#feat=css-hyphens" target="_blank">browser support <i class="new-window-link"></i></a>:</p>
 
         <ul>
             <li>IE 10+</li>

--- a/less/text-styles.less
+++ b/less/text-styles.less
@@ -16,7 +16,13 @@ a {
 
 a {
   .new-window-link, .insecure-link {
-    .fa();
+    .fas();
+    // Partial copy of .fa-icon() from _mixins.less
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    display: inline-block;
+    font-style: normal;
+    font-variant: normal;
     font-size: @font-size-small;
     padding-left: 3px;
     margin-right: 2px;


### PR DESCRIPTION
Didn't mix in fa-icon() directly as it included some styles that we would have to override, so keeping the output slim by only including what we need.

Also fix the HTML on the example page to how it's intended to be used - it wasn't showing anything before.