### PR TITLE
ID-291 Orange outlines for :focus'd elements

### DIFF
--- a/less/accessibility.less
+++ b/less/accessibility.less
@@ -1,0 +1,4 @@
+.tab-focus() {
+  outline-offset: 0;
+  outline: 3px solid @focus-outline;
+}

--- a/less/id7-no-fa.less
+++ b/less/id7-no-fa.less
@@ -60,6 +60,7 @@
 
 // ID7 layout classes
 @import 'main.less';
+@import 'accessibility.less';
 @import 'fixed-width-container.less';
 @import 'header.less';
 @import 'search.less';

--- a/less/variables.less
+++ b/less/variables.less
@@ -174,3 +174,5 @@
 @alert-danger-border: @alert-danger-bg;
 
 @id7-ignore-id6-legacy: false;
+
+@focus-outline: #ffbf47;


### PR DESCRIPTION
This PR adds a gov.uk style orange `:focus` outline for accessibility. This currently applies to all elements, which may or may not be desirable (we could restrict to just `a`).

Screenshots:
------------

**Normal link**

![image](https://user-images.githubusercontent.com/2552726/59020161-57df1400-8841-11e9-95c8-b807d83a4495.png)


**Navbar**

![image](https://user-images.githubusercontent.com/2552726/59019366-d470f300-883f-11e9-9d5d-a5cdf5c3a097.png)


**Other fields**

![image](https://user-images.githubusercontent.com/2552726/59019375-d6d34d00-883f-11e9-9ee9-3b40631378af.png)

Video showing different colour navbars is on Slack.