### PR TITLE
Bump version to 2.3.9 for release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,4 +17,4 @@ encoding:         UTF-8
 prefix:           /
 
 # Custom variables
-current_version:  2.3.8
+current_version:  2.3.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofwarwick/id7",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "scripts": {
     "watch": "NODE_ENV=development webpack --mode development --watch",
     "dev": "NODE_ENV=development webpack --mode development",


### PR DESCRIPTION
Release Notes - Brand - Version 2.3.9
                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://bugs.elab.warwick.ac.uk/browse/ID-288'>ID-288</a>] -         Mobile popover rules activating for some desktops
</li>
<li>[<a href='https://bugs.elab.warwick.ac.uk/browse/ID-318'>ID-318</a>] -         Sign out not visible in some Chromes v74+
</li>
</ul>
                    
<h2>        Improvement
</h2>
<ul>
<li>[<a href='https://bugs.elab.warwick.ac.uk/browse/ID-316'>ID-316</a>] -         &quot;Skip to navigation&quot; link
</li>
</ul>
                        