### PR TITLE
Bump to version v2.4.2 for release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,4 +17,4 @@ encoding:         UTF-8
 prefix:           /
 
 # Custom variables
-current_version:  2.4.1
+current_version:  2.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universityofwarwick/id7",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "scripts": {
     "watch": "NODE_ENV=development webpack --mode development --watch",
     "dev": "NODE_ENV=development webpack --mode development",


### PR DESCRIPTION

Release Notes - Brand - Version 2.4.2
                                                        
<h2>        Improvement
</h2>
<ul>
<li>[<a href='https://bugs.elab.warwick.ac.uk/browse/ID-324'>ID-324</a>] -         handle horizontal scroll on non-safari browsers on mac
</li>
</ul>
                        