### PR TITLE
TAB-7285 post fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,7 @@ In your application you will need to do the following:
 * `id7-standalone.js` was removed from the distribution; you should build your own bundle if you are using this
 
 ## Horizontal scroll on table-responsive on mac
-`.table-responsive` uses jqDoubleScroll, and by default, we hide the system scrollbar to prevent duplicate scrollbars being rendered. On macOS using a non-Safari browser, this would prevent the user from scrolling horizontally. Hence, in `wide-tables.jquery.js` we explicitly let non-Safari browsers running on macOS render the system scrollbar. Since it is hard to tell how `table-responsive` will be embedded into a page, and one might want to do something extra on top of our special handling, we have an event named `non-safari-mac-post-init.id7:table-responsive` for executing any extra steps if needed which fires after the page is ready. e.g.
-```
-$('body').trigger('non-safari-mac-post-init.id7:table-responsive', function () {
-  // add your own code here
-});
-``` 
+`.table-responsive` uses jqDoubleScroll, and by default, we hide the system scrollbar to prevent duplicate scrollbars being rendered. On macOS using a non-Safari browser, this would prevent the user from scrolling horizontally. Hence, in `wide-tables.jquery.js` we explicitly let non-Safari browsers running on macOS render the system scrollbar, and hide `.doubleScroll-scroll-wrapper`.
 
 ## Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In your application you will need to do the following:
 ## Horizontal scroll on table-responsive on mac
 `.table-responsive` uses jqDoubleScroll, and by default, we hide the system scrollbar to prevent duplicate scrollbars being rendered. On macOS using a non-Safari browser, this would prevent the user from scrolling horizontally. Hence, in `wide-tables.jquery.js` we explicitly let non-Safari browsers running on macOS render the system scrollbar. Since it is hard to tell how `table-responsive` will be embedded into a page, and one might want to do something extra on top of our special handling, we have an event named `non-safari-mac-post-init.id7:table-responsive` for executing any extra steps if needed which fires after the page is ready. e.g.
 ```
-$('body').on('non-safari-mac-post-init.id7:table-responsive', function () {
+$('body').trigger('non-safari-mac-post-init.id7:table-responsive', function () {
   // add your own code here
 });
 ``` 

--- a/js/wide-tables.jquery.js
+++ b/js/wide-tables.jquery.js
@@ -28,7 +28,6 @@ const Config = {
       return FeatureDetect.mq('only all and (min-width: 768px)');
     },
     doublescroll: true,
-    namespace: 'id7:table-responsive',
   },
 };
 
@@ -121,14 +120,6 @@ class WideTables {
   }
 }
 
-function notSafari() {
-  return !(navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1);
-}
-
-function onMac() {
-  return navigator.platform === 'MacIntel';
-}
-
 $.fn.wideTables = function wideTablesPlugin(options) {
   const o = options || {};
 
@@ -141,23 +132,20 @@ $.fn.wideTables = function wideTablesPlugin(options) {
     $container.data('id7.wide-tables', wideTables);
   }
 
-  if (notSafari()) {
-    if (onMac()) {
+  if (!(navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1)) {
+    if (navigator.platform === 'MacIntel') {
       // show scroll bar on non-safari browsers on mac
       // otherwise mac user would not be able to scroll horizontally
       // because the double scroll element might not be visible
       // (and macgic mouse/trackpad horizontal scroll would not work unless on safari.)
       $('.table-responsive').css('overflow-x', 'scroll');
+      $('.doubleScroll-scroll-wrapper').hide(); // hide double scroll, as this is not needed in this case
     } else {
       $('.table-responsive').css('overflow-x', 'hidden');
     }
   }
   return this.each(attach);
 };
-
-$(window).on(`non-safari-mac-post-init.${Config.Defaults.namespace}`, (e, callback) => {
-  if (notSafari() && onMac() && callback) callback(); // do extra things if needed.
-});
 
 // SBTWO-5105 check tables after load, in case contents cause resize
 $(window).on('load id7:ready', () => $('.id7-main-content').wideTables());

--- a/js/wide-tables.jquery.js
+++ b/js/wide-tables.jquery.js
@@ -121,6 +121,14 @@ class WideTables {
   }
 }
 
+function notSafari() {
+  return !(navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1);
+}
+
+function onMac() {
+  return navigator.platform === 'MacIntel';
+}
+
 $.fn.wideTables = function wideTablesPlugin(options) {
   const o = options || {};
 
@@ -133,21 +141,23 @@ $.fn.wideTables = function wideTablesPlugin(options) {
     $container.data('id7.wide-tables', wideTables);
   }
 
-  if (!(navigator.userAgent.indexOf('Safari') !== -1 && navigator.userAgent.indexOf('Chrome') === -1)) {
-    if (navigator.platform === 'MacIntel') {
+  if (notSafari()) {
+    if (onMac()) {
       // show scroll bar on non-safari browsers on mac
       // otherwise mac user would not be able to scroll horizontally
       // because the double scroll element might not be visible
       // (and macgic mouse/trackpad horizontal scroll would not work unless on safari.)
       $('.table-responsive').css('overflow-x', 'scroll');
-      $('body').trigger(`non-safari-mac-post-init.${Config.Defaults.namespace}`);
     } else {
       $('.table-responsive').css('overflow-x', 'hidden');
     }
   }
-
   return this.each(attach);
 };
+
+$(window).on(`non-safari-mac-post-init.${Config.Defaults.namespace}`, (e, callback) => {
+  if (notSafari() && onMac() && callback) callback(); // do extra things if needed.
+});
 
 // SBTWO-5105 check tables after load, in case contents cause resize
 $(window).on('load id7:ready', () => $('.id7-main-content').wideTables());


### PR DESCRIPTION
previously had ID7 triggers event `non-safari-mac-post-init.id7:table-responsive` seems to be an incorrect approach, as it's most likely have that event is triggered before implementer's listener is registered.

changes to have ID7 listens to the event and execute the callback, and let implementer triggers the event.
