### PR TITLE
Tweak outline sizes

### DIFF
--- a/less/masthead.less
+++ b/less/masthead.less
@@ -83,6 +83,7 @@
 
     img {
       .opacity(0);
+      height: 100%; // BZ-687311
     }
   }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -35,8 +35,8 @@
 @id7-masthead-bleed-height: 24px;
 @id7-masthead-logo-height-xs: 54px;
 @id7-masthead-logo-height-sm: 80px;
-@id7-masthead-logo-width-xs: 125px;
-@id7-masthead-logo-width-sm: 180px;
+@id7-masthead-logo-width-xs: 110px;
+@id7-masthead-logo-width-sm: 160px;
 
 @id7-masthead-search-offset-xs: 7px;
 @id7-masthead-search-offset-sm: 32px;


### PR DESCRIPTION
In Firefox, outlines take into account child elements.

This PR fixes the size of the outline in Firefox, where it was previously too big. Right click -> open image should still work in Chrome.

Before:
![image](https://user-images.githubusercontent.com/2552726/60825821-728c0c00-a1a4-11e9-8b00-618f92f86358.png)
