### PR TITLE
ID-357 Use GDS inspired focus indicator.

### DIFF
--- a/less/accessibility.less
+++ b/less/accessibility.less
@@ -1,5 +1,9 @@
 .id7-outline() {
-  outline: 3px solid @focus-outline;
+  outline: 3px solid transparent;
+  color: #0b0c0c !important;
+  background-color: @focus-outline !important;
+  box-shadow: 0 -2px @focus-outline, 0 4px #0b0c0c;
+  text-decoration: none !important;
 }
 
 .tab-focus() {


### PR DESCRIPTION
Lamentable use of the important in the styles - judged it to be simpler than to add a set of overrides for all the things with more important backgrounds and borders.