### PR TITLE
Allow sandboxed iframe to create unsandboxed popups

### DIFF
--- a/js/account-popover.jquery.js
+++ b/js/account-popover.jquery.js
@@ -15,7 +15,7 @@ const Config = {
         <iframe src="${_.escape(o.useMwIframe ? `${o.iframelink}?embedded` : o.legacyIframeLink)}" 
                 scrolling="auto" frameborder="0" allowtransparency="true" 
                 seamless 
-                sandbox="allow-same-origin allow-scripts allow-top-navigation allow-forms allow-popups"></iframe>
+                sandbox="allow-same-origin allow-scripts allow-top-navigation allow-forms allow-popups allow-popups-to-escape-sandbox"></iframe>
         </div>
         <div class="actions">
           <div class="btn-group btn-group-justified">


### PR DESCRIPTION
This is the ultimate cause of our woes with COOP, because the pop-up would otherwise inherit the sandbox flags applied to the iframe - even though it's top-level and not a navigation inside the iframe.

Due to the requirement to have a "clean slate" for COOP sites (as part of the process isolation design goal), the position adopted by browser vendors was that it was undesirable to have the sandbox flags persist in the new context that has come about due to COOP and so the navigation is blocked instead.

This PR is the long term fix alongside the T&T short term fix that I opened a [PR](https://repo.elab.warwick.ac.uk/projects/TAT/repos/app/pull-requests/124/overview) for. I believe that once _this_ ID7 PR is merged/deployed widely enough (probably Sitebuilder will do), we can revert today's T&T PR.