### PR TITLE
ID-402 Fix sticky header changing size when scrolling on wide pages

### DIFF
--- a/less/masthead.less
+++ b/less/masthead.less
@@ -139,6 +139,14 @@
         width: @container-lg;
       }
 
+      @media screen and (min-width: @screen-xl-min) {
+        width: @container-xl;
+      }
+
+      @media screen and (min-width: @screen-2xl-min) {
+        width: @container-2xl;
+      }
+
       &.headroom {
         transition: transform 100ms linear;
       }


### PR DESCRIPTION
Target for what was affixed in a masthead was changed at some point, so `affix` is now applied to the whole masthead instead of the title. However, the title is smaller than the container, and we have some large containers that weren't included. Width of sticky header should now be correct when scrolling instead of jumping around.