### PR TITLE
ID-408 Reintroduce Warwick Green.

### DIFF
--- a/docs/assets/site/docs-site.less
+++ b/docs/assets/site/docs-site.less
@@ -229,4 +229,7 @@
   &.blue {
     .swatch-colors(@id7-brand-blue)
   }
+  &.green {
+    .swatch-colors(@id7-brand-green)
+  }
 }

--- a/docs/components/colour-palette/index.html
+++ b/docs/components/colour-palette/index.html
@@ -7,7 +7,7 @@ slug: components/colour-palette
 <h2>Primary colour palette</h2>
 
 <div class="row">
-    <div class="col-sm-6">
+    <div class="col-sm-4">
         <div class="id7-docs-palette-logo purple pull-left"></div>
 
         <dl class="pull-left">
@@ -19,7 +19,7 @@ slug: components/colour-palette
             <dd class="secondary purple swatch">#886C91</dd>
         </dl>
     </div>
-    <div class="col-sm-6">
+    <div class="col-sm-4">
         <div class="id7-docs-palette-logo gray pull-left"></div>
 
         <dl class="pull-left">
@@ -31,7 +31,7 @@ slug: components/colour-palette
             <dd class="secondary gray swatch">#747576</dd>
         </dl>
     </div>
-    <div class="col-sm-6">
+    <div class="col-sm-4">
         <div class="id7-docs-palette-logo red pull-left"></div>
 
         <dl class="pull-left">
@@ -43,7 +43,7 @@ slug: components/colour-palette
             <dd class="secondary red swatch">#B85A58</dd>
         </dl>
     </div>
-    <div class="col-sm-6">
+    <div class="col-sm-4">
         <div class="id7-docs-palette-logo blue pull-left"></div>
 
         <dl class="pull-left">
@@ -55,8 +55,20 @@ slug: components/colour-palette
             <dd class="secondary blue swatch">#4D79A2</dd>
         </dl>
     </div>
-</div>
+    <div class="col-sm-4">
+        <div class="id7-docs-palette-logo green pull-left"></div>
 
+        <dl class="pull-left">
+            <dt>Name</dt>
+            <dd>Warwick Green</dd>
+            <dt>Primary Hex</dt>
+            <dd class="primary green swatch">#0F4001</dd>
+            <dt>Secondary Hex</dt>
+            <dd class="secondary green swatch">#57794D</dd>
+        </dl>
+    </div>
+</div>
+<!-- 
 <h2 id="tints">Tints</h2>
 
 <table class="table">
@@ -139,4 +151,4 @@ slug: components/colour-palette
             <td><div class="tint-5 id7-docs-palette-logo blue tint"></div></td>
         </tr>
     </tbody>
-</table>
+</table> -->

--- a/less/variables.less
+++ b/less/variables.less
@@ -13,7 +13,7 @@
 @id7-brand-gold: #996b00;   // #886c11;   // hsl(46, 78%, 44%) originally #c8a019 - unreferenced in public info (ID-363)
 @id7-brand-orange: #be410c; // #a14418; // hsl(19, 89%, 54%) originally #f26322 now hsl(19, 74%, 36%) - unreferenced in public info (ID-363)
 @id7-brand-red: #9A1310;    // hsl(1, 40%, 53%) originally #b4153a now hsl(346, 79%, 30%)
-@id7-brand-green: #797906;  // hsl(60, 90%, 32%) originally #9a9a08 now hsl(60, 90%, 25%) - unreferenced in public info (ID-363)
+@id7-brand-green: #0F4001; 
 @id7-brand-blue: #00407A;   // hsl(209, 36%, 47%) originally #5698d2 now hsl(208, 58%, 30%)
 
 @id7-brand-gold-bright: #ffc233; // unreferenced in public info (ID-363)


### PR DESCRIPTION
This changes the colour of an existing variable, @id7-brand-green, which had been removed a few years ago presumably because it was a horrible colour. It's back now and it is dark