### PR TITLE
SBTWO-10013 Have no transformation on Search Warwick input label so it will not overflow and cause cookie banner to scroll in two dimensions.

### DIFF
--- a/less/floating-labels.less
+++ b/less/floating-labels.less
@@ -22,6 +22,11 @@
   }
   
   @media (max-width: @screen-sm-min) {
+    input:placeholder-shown ~ label {
+      // SBTWO-10013 Do no transformation on Search Warwick input label so it will not overflow
+      transform: none;
+    }
+
     label {
       visibility: hidden;
       opacity: 0;


### PR DESCRIPTION
Have no transformation on Search Warwick input label so it will not overflow and cause the cookie banner to scroll in two dimensions.
Link to related JIRA: https://bugs.elab.warwick.ac.uk/browse/SBTWO-10013.