### PR TITLE
ID-414 Update brand colours.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Documentation, included in this repo in the root directory, is built with [Jekyl
 1. In the root `/id7` directory:
     1. Run `bundle install` to install dependent gems.
     1. Run `npm ci` to install webpack and other node.js dependencies.
+    1. Run `npm run dev` (or `npm run watch`) to build a copy of static assets.
     1. Run `npm run start` in the command line.
 1. Open <http://localhost:8080> in your browser, et voilà.
 

--- a/docs/assets/site/docs-site.less
+++ b/docs/assets/site/docs-site.less
@@ -200,7 +200,7 @@
   &.gold   { .docs-palette-logo(@id7-brand-gold); }   &.gold-bright   { .docs-palette-logo(@id7-brand-gold-bright); }
   &.orange { .docs-palette-logo(@id7-brand-orange); } &.orange-bright { .docs-palette-logo(@id7-brand-orange-bright); }
   &.red    { .docs-palette-logo(@id7-brand-red); }    &.red-bright    { .docs-palette-logo(@id7-brand-red-bright); }
-  &.green  { .docs-palette-logo(@id7-brand-green); }  &.green-bright  { .docs-palette-logo(@id7-brand-green-bright); }
+  &.teal   { .docs-palette-logo(@id7-brand-teal); }   &.teal-bright   { .docs-palette-logo(@id7-brand-teal-bright); }
   &.blue   { .docs-palette-logo(@id7-brand-blue); }   &.blue-bright   { .docs-palette-logo(@id7-brand-blue-bright); }
 }
 
@@ -229,7 +229,7 @@
   &.blue {
     .swatch-colors(@id7-brand-blue)
   }
-  &.green {
-    .swatch-colors(@id7-brand-green)
+  &.teal {
+    .swatch-colors(@id7-brand-teal)
   }
 }

--- a/docs/components/colour-palette/index.html
+++ b/docs/components/colour-palette/index.html
@@ -4,7 +4,12 @@ title: Colour palette
 slug: components/colour-palette
 ---
 
-<h2>Primary colour palette</h2>
+<div class="panel panel-info">
+    <div class="panel-body">
+    Visit the official <a href="https://warwick.ac.uk/brand/brand-guidelines/colours/">Colour palette page on the Brand Portal</a> for the full set of brand colours.
+    </div>
+</div>
+
 
 <div class="row">
     <div class="col-sm-4">
@@ -14,9 +19,9 @@ slug: components/colour-palette
             <dt>Name</dt>
             <dd>Warwick Aubergine</dd>
             <dt>Primary Hex</dt>
-            <dd class="primary purple swatch">#552D62</dd>
+            <dd class="primary purple swatch">#3C1053</dd>
             <dt>Secondary Hex</dt>
-            <dd class="secondary purple swatch">#886C91</dd>
+            <dd class="secondary purple swatch">#775887</dd>
         </dl>
     </div>
     <div class="col-sm-4">
@@ -26,9 +31,9 @@ slug: components/colour-palette
             <dt>Name</dt>
             <dd>Warwick Gray</dd>
             <dt>Primary Hex</dt>
-            <dd class="primary gray swatch">#393A3B</dd>
+            <dd class="primary gray swatch">#58595B</dd>
             <dt>Secondary Hex</dt>
-            <dd class="secondary gray swatch">#747576</dd>
+            <dd class="secondary gray swatch">#8A8B8C</dd>
         </dl>
     </div>
     <div class="col-sm-4">
@@ -36,11 +41,11 @@ slug: components/colour-palette
 
         <dl class="pull-left">
             <dt>Name</dt>
-            <dd>Warwick Ruby red</dd>
+            <dd>Dark Ruby</dd>
             <dt>Primary Hex</dt>
-            <dd class="primary red swatch">#9A1310</dd>
+            <dd class="primary red swatch">#9D2235</dd>
             <dt>Secondary Hex</dt>
-            <dd class="secondary red swatch">#B85A58</dd>
+            <dd class="secondary red swatch">#BA6472</dd>
         </dl>
     </div>
     <div class="col-sm-4">
@@ -48,23 +53,23 @@ slug: components/colour-palette
 
         <dl class="pull-left">
             <dt>Name</dt>
-            <dd>Warwick Sky blue</dd>
+            <dd>Dark Blue</dd>
             <dt>Primary Hex</dt>
-            <dd class="primary blue swatch">#00407A</dd>
+            <dd class="primary blue swatch">#41748D</dd>
             <dt>Secondary Hex</dt>
-            <dd class="secondary blue swatch">#4D79A2</dd>
+            <dd class="secondary blue swatch">#7A9EAF</dd>
         </dl>
     </div>
     <div class="col-sm-4">
-        <div class="id7-docs-palette-logo green pull-left"></div>
+        <div class="id7-docs-palette-logo teal pull-left"></div>
 
         <dl class="pull-left">
             <dt>Name</dt>
-            <dd>Warwick Green</dd>
+            <dd>Dark Teal</dd>
             <dt>Primary Hex</dt>
-            <dd class="primary green swatch">#0F4001</dd>
+            <dd class="primary teal swatch">#507F70</dd>
             <dt>Secondary Hex</dt>
-            <dd class="secondary green swatch">#57794D</dd>
+            <dd class="secondary teal swatch">#84A59B</dd>
         </dl>
     </div>
 </div>

--- a/less/variables.less
+++ b/less/variables.less
@@ -6,21 +6,37 @@
 @container-desktop:         (950px + @grid-gutter-width);
 @container-large-desktop:   (1150px + @grid-gutter-width);
 
-// Primary colour palette   // Secondary colour palette
-@id7-brand-purple: #552D62; // hsl(285, 15%, 50%) originally #7b428e
-@id7-brand-gray: #393A3B;   // hsl(210, 1%, 46%)
-@id7-brand-white: #ffffff;
-@id7-brand-gold: #996b00;   // #886c11;   // hsl(46, 78%, 44%) originally #c8a019 - unreferenced in public info (ID-363)
-@id7-brand-orange: #be410c; // #a14418; // hsl(19, 89%, 54%) originally #f26322 now hsl(19, 74%, 36%) - unreferenced in public info (ID-363)
-@id7-brand-red: #9A1310;    // hsl(1, 40%, 53%) originally #b4153a now hsl(346, 79%, 30%)
-@id7-brand-green: #0F4001; 
-@id7-brand-blue: #00407A;   // hsl(209, 36%, 47%) originally #5698d2 now hsl(208, 58%, 30%)
+///
+// https://warwick.ac.uk/about/brand/brand-guidelines/colours/
+///
 
-@id7-brand-gold-bright: #ffc233; // unreferenced in public info (ID-363)
-@id7-brand-orange-bright: #f47920; // unreferenced in public info (ID-363)
-@id7-brand-red-bright: #ef4050; // unreferenced in public info (ID-363)
-@id7-brand-green-bright: #7ecbb6; // unreferenced in public info (ID-363)
-@id7-brand-blue-bright: #00b2dd; // unreferenced in public info (ID-363)
+// Primary brand colour - Aubergine
+@id7-brand-purple: #3C1053; 
+
+// "Text and background colours"
+@id7-brand-black: #000000; // inspired
+@id7-brand-gray: #58595B;
+@id7-brand-white: #FFFFFF; // wow
+
+// Secondary palette (bright)
+@id7-brand-gold-bright: #F1BE48; 
+@id7-brand-orange-bright: #E87722; 
+@id7-brand-red-bright: #CB333B; 
+@id7-brand-blue-bright: #00A9CE; 
+@id7-brand-teal-bright: #6DCDB8;
+
+// Tertiary palette (dark)
+@id7-brand-gold: #D69A2D;   
+@id7-brand-orange: #BE531C; 
+@id7-brand-red: #9D2235;    
+@id7-brand-blue: #41748D;   
+@id7-brand-teal: #507F70;
+
+// Green is no longer a colour in the brand palette, but keeping here
+// for backward compatibility. Could alias it to teal?
+@id7-brand-green: #0F4001; 
+@id7-brand-green-bright: #7ecbb6;
+
 
 @id7-brand-default: @id7-brand-purple;
 


### PR DESCRIPTION
Docs page updated for the colours we currently show (replacing green with teal), and a link to the full brand palette page on Sitebuilder.

The primary purple colour has been changed so that's likely to be the main change noticeable when updating ID7. Otherwise only if you had referenced any of the other brand colours.

May need to wait for ID-426 to push these out as the new colours may not pair with the most contrasting text colour using the existing contrast algorithm.