### PR TITLE
ID-426 Add a little notice to the top.

### DIFF
--- a/docs/_data/brand_palette.yml
+++ b/docs/_data/brand_palette.yml
@@ -1,0 +1,31 @@
+---
+# Colour Palette as displayed in colour-palette/index.html.
+# Based on https://warwick.ac.uk/about/brand/brand-guidelines/colours/
+# The primary and secondary colours are manually managed here.
+- id: purple
+  name: Aubergine
+  include_in_palette: true
+  primary: "#3C1053"
+  secondary: "#775887"
+- id: gray
+  name: Gray
+  include_in_palette: true
+  primary: "#3C1053"
+  secondary: "#775887"
+- id: orange
+  name: Dark Orange
+- id: red
+  name: Dark Ruby
+  include_in_palette: true
+  primary: "#9D2235"
+  secondary: "BA6472"
+- id: blue
+  name: Dark Blue
+  include_in_palette: true
+  primary: "#41748D"
+  secondary: "#7A9EAF"
+- id: teal
+  name: Dark Teal
+  include_in_palette: true
+  primary: "#507F70"
+  secondary: "#84A59B"

--- a/docs/assets/css/config-options.less
+++ b/docs/assets/css/config-options.less
@@ -3,12 +3,26 @@
 @import (reference) '../../../less/variables.less';
 @import (reference) '../../../less/mixins.less';
 
-body {
-  &.brand-purple { .apply-brand(@id7-brand-purple); }
-  &.brand-gray { .apply-brand(@id7-brand-gray); }
-  &.brand-gold { .apply-brand(@id7-brand-gold); }
-  &.brand-blue { .apply-brand(@id7-brand-blue); }
-  &.brand-orange { .apply-brand(@id7-brand-orange); }
-  &.brand-green { .apply-brand(@id7-brand-green); }
-  &.brand-red { .apply-brand(@id7-brand-red); }
-}
+// These are not CSS colors
+@brand-names: purple,
+  gray,
+  gold,
+  gold-bright,
+  blue,
+  blue-bright,
+  orange,
+  orange-bright,
+  green,
+  teal,
+  teal-bright,
+  red,
+  red-bright;
+
+each(@brand-names,
+  {
+  @brand-var: "id7-brand-@{value}";
+
+  .brand-@{value} {
+    .apply-brand(@@brand-var);
+  }
+});

--- a/docs/components/colour-palette/index.html
+++ b/docs/components/colour-palette/index.html
@@ -4,74 +4,37 @@ title: Colour palette
 slug: components/colour-palette
 ---
 
-<div class="panel panel-info">
-    <div class="panel-body">
+<div class="alert alert-info">
+    <p>
     Visit the official <a href="https://warwick.ac.uk/brand/brand-guidelines/colours/">Colour palette page on the Brand Portal</a> for the full set of brand colours.
-    </div>
+    </p>
 </div>
 
+<div class="alert alert-warning">
+    <p>We are currently in the process of checking the new colour palette for accessibility and updating our contrast functions. This is to ensure that our website meets the necessary standards for all users, including those with visual impairments. In the meantime you may find that not all colours offered in the full palette are suitable as a site brand colour. We apologize for any inconvenience caused during this transition period.</p>
+</div>
 
 <div class="row">
+    {% comment %}
+        This data is defined in _data/brand_palette.yml
+    {% endcomment %}
+
+    {% for brand in site.data.brand_palette %}
+    {% if brand.include_in_palette %}
     <div class="col-sm-4">
-        <div class="id7-docs-palette-logo purple pull-left"></div>
+        <div class="id7-docs-palette-logo {{ brand.id }} pull-left"></div>
 
         <dl class="pull-left">
             <dt>Name</dt>
-            <dd>Warwick Aubergine</dd>
+            <dd>{{ brand.name }}</dd>
             <dt>Primary Hex</dt>
-            <dd class="primary purple swatch">#3C1053</dd>
+            <dd class="primary {{ brand.id }} swatch">{{ brand.primary }}</dd>
             <dt>Secondary Hex</dt>
-            <dd class="secondary purple swatch">#775887</dd>
+            <dd class="secondary {{ brand.id }} swatch">{{ brand.secondary }}</dd>
         </dl>
     </div>
-    <div class="col-sm-4">
-        <div class="id7-docs-palette-logo gray pull-left"></div>
-
-        <dl class="pull-left">
-            <dt>Name</dt>
-            <dd>Warwick Gray</dd>
-            <dt>Primary Hex</dt>
-            <dd class="primary gray swatch">#58595B</dd>
-            <dt>Secondary Hex</dt>
-            <dd class="secondary gray swatch">#8A8B8C</dd>
-        </dl>
-    </div>
-    <div class="col-sm-4">
-        <div class="id7-docs-palette-logo red pull-left"></div>
-
-        <dl class="pull-left">
-            <dt>Name</dt>
-            <dd>Dark Ruby</dd>
-            <dt>Primary Hex</dt>
-            <dd class="primary red swatch">#9D2235</dd>
-            <dt>Secondary Hex</dt>
-            <dd class="secondary red swatch">#BA6472</dd>
-        </dl>
-    </div>
-    <div class="col-sm-4">
-        <div class="id7-docs-palette-logo blue pull-left"></div>
-
-        <dl class="pull-left">
-            <dt>Name</dt>
-            <dd>Dark Blue</dd>
-            <dt>Primary Hex</dt>
-            <dd class="primary blue swatch">#41748D</dd>
-            <dt>Secondary Hex</dt>
-            <dd class="secondary blue swatch">#7A9EAF</dd>
-        </dl>
-    </div>
-    <div class="col-sm-4">
-        <div class="id7-docs-palette-logo teal pull-left"></div>
-
-        <dl class="pull-left">
-            <dt>Name</dt>
-            <dd>Dark Teal</dd>
-            <dt>Primary Hex</dt>
-            <dd class="primary teal swatch">#507F70</dd>
-            <dt>Secondary Hex</dt>
-            <dd class="secondary teal swatch">#84A59B</dd>
-        </dl>
-    </div>
+    {% endif %}
+    {% endfor %}
 </div>
 <!-- 
 <h2 id="tints">Tints</h2>

--- a/docs/examples/brand-testcard/index.html
+++ b/docs/examples/brand-testcard/index.html
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Testcard
+slug: examples/testcard
+---
+
+<div class="row">
+  {% for brand in site.data.brand_palette %}
+  <section class="col-sm-4 brand-{{ brand.id }}">
+      <h2>Heading 2</h2>
+      <h3>Heading 3</h3>
+      <h4>Heading 4</h4>
+      <h5>Heading 5</h5>
+      <h6>Heading 6</h6>
+
+      <p>Some text here</p>
+
+      <h2><a href="go.warwick.ac.uk/its">Link heading 2</a></h2>
+
+      <blockquote class="quotes">
+          <p>Some text here. Continues a bit further to show how it looks on multiple lines.</p>
+      </blockquote>
+      
+      {% for b in (1..5) %}
+      <div class="boxstyle_ box{{ b }}">
+        <h2>Box style {{ b }} with <a href="go.warwick.ac.uk/its">link heading 2</a> </h2>
+
+        <p>Some text here and a <a href="go.warwick.ac.uk/its">link</a></p>
+      </div>
+      {% endfor %}
+    </section>
+    {% endfor %}
+</div>


### PR DESCRIPTION
To let people know we are working on this.

Also got a bit fed up with the repetitive HTML - seems like somebody didn't know about Liquid templates. Now the brand palette is generated from some YAML data, as is a brand testcard that prints out headings, links and box styles in a range of brand colours.

Adjusted config-options.less so that these brands can be applied at any level in the document, not just to the body. Allows for having multiple themes in one page.