### PR TITLE
ID-424 CSS properties for many colours.

### DIFF
--- a/docs/assets/css/config-options.less
+++ b/docs/assets/css/config-options.less
@@ -24,5 +24,6 @@ each(@brand-names,
 
   .brand-@{value} {
     .apply-brand(@@brand-var);
+    .brand-css-variables(@@brand-var);
   }
 });

--- a/docs/assets/site/docs-site.less
+++ b/docs/assets/site/docs-site.less
@@ -5,6 +5,9 @@
 
 .apply-site-imagery("/dist/docs/site/docs-site");
 .apply-brand(@id7-brand-blue);
+:root {
+  .brand-css-variables(@id7-brand-blue);
+}
 
 // Syntax highlighting
 .hll { background-color: #ffffcc }

--- a/docs/assets/site/site.less
+++ b/docs/assets/site/site.less
@@ -19,3 +19,6 @@ html {
 }
 
 .apply-brand(@id7-brand-purple);
+:root {
+  .brand-css-variables(@id7-brand-purple);
+}

--- a/less/default-theme.less
+++ b/less/default-theme.less
@@ -19,3 +19,6 @@
 }
 
 .apply-brand(@id7-brand-default);
+:root {
+  .brand-css-variables(@id7-brand-default);
+}

--- a/less/design-tokens/all.less
+++ b/less/design-tokens/all.less
@@ -1,2 +1,3 @@
 @import "breakpoints";
 @import "reference";
+@import "colors";

--- a/less/design-tokens/colors.less
+++ b/less/design-tokens/colors.less
@@ -1,0 +1,17 @@
+
+// This can be enabled to generate a set of
+// CSS classes for switching to a different preset
+// colour scheme.
+// At the time of writing the set of colours
+// is not finalised and also nothing is themed
+// using CSS variables so they wouldn't have
+// any effect on built-in components.
+& when (@id7-generate-colour-classes) {
+  each(@id7-brand-colors, {
+    .id7-brand-@{value} {
+      @brand-color-var: "id7-brand-@{value}";
+      @brand-color: @@brand-color-var;
+      .brand-css-variables(@brand-color);
+    }
+  });
+}

--- a/less/mixins/branding.less
+++ b/less/mixins/branding.less
@@ -1,3 +1,5 @@
+// TODO add a `when (@id7-gen = 2024)` guard to slim down new brand CSS
+
 .apply-site-imagery(
   @basedir,
   @masthead-image: "masthead-image.jpg",
@@ -236,6 +238,71 @@
 
 }
 
+// Define the CSS variables for a brand colour.
+// This can't be called from the top level like apply-brand,
+// because it isn't valid CSS. In those cases you can call
+// this inside :root or inside a class, depending on when
+// you want them to apply. Normally you'd want it to be applied
+// to root at least once so it applies to the page, but you could
+// then apply another colour to a class that you can then add
+// at any level within the page to switch colour scheme.
+.brand-css-variables(@colour) {
+  @colours: .calculate-brand-colours(@colour);
+
+  --w-ref-colors-primary: @colours[@primary];
+  --w-ref-colors-secondary: @colours[@secondary];
+
+  //// Colour pairings
+
+  // Primary colour background
+  --w-sys-colors-primary: var(--w-ref-colors-primary);
+  --w-sys-colors-primary-contrast: @colours[@primary-contrast]; // black or white
+
+  // Set of tints of the primary colour.
+  // Copying Bootstrap 5's 100-900 system.
+  @scale-values:
+          100 80%, // lightest
+          200 60%,
+          300 40%,
+          400 20%,
+          500 0%,  // 500 is always the base colour
+          600 20%,
+          700 40%,
+          800 60%,
+          900 80%; // darkest
+
+  each(@scale-values, {
+    @step: extract(@value, 1);
+    @percent: extract(@value, 2);
+
+    @mix-color: if(@step < 500, #ffffff, if(@step > 500, #000000, @colour));
+    @final-color: if(@step = 500, @colour, mix(@mix-color, @colour, @percent));
+
+    --w-sys-colors-primary-@{step}: @final-color;
+    --w-sys-colors-primary-@{step}-contrast: #wcag.contrast(@final-color, white, @text-color)[];
+  });
+
+  // Secondary colour background
+  --w-sys-colors-secondary: @colours[@secondary];
+  --w-sys-colors-secondary-contrast: @colours[@secondary-contrast];
+  --w-sys-colors-secondary-accent: @colours[@secondary-accent];
+
+  // A colour we can place on white - can fall back to black
+  --w-sys-colors-white-accent: @colours[@white-emphasis];
+  // Slightly deeper colour (or black again)
+  --w-sys-colors-white-deepAccent: @colours[@white-deep-emphasis];
+
+  --w-sys-colors-pale: @colours[@pale];
+  --w-sys-colors-pale-accent: @colours[@pale-emphasis];
+
+  // This grey doesn't depend on the brand colour
+  // but the emphasis colour does - may as well keep
+  // them together.
+  --w-sys-colors-paleGrey: @colours[@pale-grey];
+  --w-sys-colors-paleGrey-accent: @colours[@pale-grey-emphasis];
+}
+
+// Generates the CSS for a brand colour
 .apply-brand(@colour) {
 
   @colours: .calculate-brand-colours(@colour);

--- a/less/tokens.less
+++ b/less/tokens.less
@@ -1,0 +1,14 @@
+@import (reference) "variables";
+
+// value/reference tokens - these should generally only be referred to by other tokens,
+// to allow swapping out for theming.
+:root {
+  --id7-ref-purple: @id7-brand-purple;
+  --id7-ref-purple-contrast: white;
+}
+
+// system tokens - overridden by themes
+:root {
+  --id7-sys-primary-bg: var(--id7-ref-purple);
+  --id7-sys-primary-on-bg: var(--id7-ref-)
+}

--- a/less/variables.less
+++ b/less/variables.less
@@ -43,6 +43,11 @@
 @id7-brand-blue: #41748D;
 @id7-brand-teal: #507F70;
 
+// A fixed set of colours for which we'll generate some CSS variables
+// wrapped in classes. Actual set WIP (awaiting new colour values)
+@id7-brand-colors: gold-bright, blue-bright, teal-bright;
+@id7-generate-colour-classes: false; // don't actually generate them right now
+
 // Green is no longer a colour in the brand palette, but keeping here
 // for backward compatibility. Could alias it to teal?
 @id7-brand-green: #0F4001;


### PR DESCRIPTION
In addition to .apply-brand you also now need to apply the new mixin at the relevant level, usually inside a `:root`.