### PR TITLE
ID-446 Define new colour palette.

### DIFF
--- a/docs/assets/css/config-options.less
+++ b/docs/assets/css/config-options.less
@@ -12,7 +12,6 @@
   blue-bright,
   orange,
   orange-bright,
-  green,
   teal,
   teal-bright,
   red,

--- a/less/design-tokens/colors.less
+++ b/less/design-tokens/colors.less
@@ -1,3 +1,22 @@
+@import (reference) "../mixins/branding";
+@import (reference) "../variables";
+
+:root {
+  /* Reference tokens (don't use directly) */
+  --w-ref-colors-page-light: white;
+  --w-ref-colors-page-light-contrast: @text-color;
+  --w-ref-colors-page-dark: @text-color;
+  --w-ref-colors-page-dark-contrast: white;
+
+  // System tokens
+  /* Page colour and default text colour */
+  --w-sys-colors-page: var(--w-ref-colors-page-light);
+  --w-sys-colors-page-contrast: var(--w-ref-colors-page-light-contrast);
+
+  /* Current background and contrasting text colour */
+  --w-sys-colors-bg: var(--w-sys-colors-page);
+  --w-sys-colors-bg-contrast: var(--w-sys-colors-page-contrast);
+}
 
 // This can be enabled to generate a set of
 // CSS classes for switching to a different preset
@@ -7,11 +26,20 @@
 // using CSS variables so they wouldn't have
 // any effect on built-in components.
 & when (@id7-generate-colour-classes) {
-  each(@id7-brand-colors, {
-    .id7-brand-@{value} {
+  :root {
+    /*
+      Definitions for brand colour palette and tints.
+      Don't use these reference values directly - use the --w-sys-colors-primary-*
+      aliases instead and choose the colour for that area with the `id7-brand-COLORNAME` classes.
+     */
+    each(@id7-brand-colors, {
       @brand-color-var: "id7-brand-@{value}";
       @brand-color: @@brand-color-var;
-      .brand-css-variables(@brand-color);
-    }
+      .colour-css-variables(@value, ref, @brand-color);
+    });
+  }
+  // Generate CSS classes that alias sys-colors-primary to a given colour.
+  each(@id7-brand-colors, {
+    .colour-sys-aliases(@value);
   });
 }

--- a/less/main-content/box-styles.less
+++ b/less/main-content/box-styles.less
@@ -17,3 +17,13 @@
 .boxstyle-lg {
   .make-lg-boxstyle();
 }
+
+each(range(1,9), {
+  @step: @value * 100;
+  // class name borrowed from https://getbootstrap.com/docs/5.0/utilities/background/
+  // though we include the tint level, and we set colour
+  .bg-primary-@{step} {
+    background-color: ~"var(--w-sys-colors-primary-@{step})";
+    color:            ~"var(--w-sys-colors-primary-@{step}-contrast)";
+  }
+})

--- a/less/mixins/box-styles.less
+++ b/less/mixins/box-styles.less
@@ -255,13 +255,3 @@
     }
   }
 }
-
-each(range(1,9), {
-  @step: @value * 100;
-  // class name borrowed from https://getbootstrap.com/docs/5.0/utilities/background/
-  // though we include the tint level, and we set colour
-  .bg-primary-@{step} {
-    background-color: ~"var(--w-sys-colors-primary-@{step})";
-    color:            ~"var(--w-sys-colors-primary-@{step}-contrast)";
-  }
-})

--- a/less/mixins/box-styles.less
+++ b/less/mixins/box-styles.less
@@ -255,3 +255,13 @@
     }
   }
 }
+
+each(range(1,9), {
+  @step: @value * 100;
+  // class name borrowed from https://getbootstrap.com/docs/5.0/utilities/background/
+  // though we include the tint level, and we set colour
+  .bg-primary-@{step} {
+    background-color: ~"var(--w-sys-colors-primary-@{step})";
+    color:            ~"var(--w-sys-colors-primary-@{step}-contrast)";
+  }
+})

--- a/less/mixins/branding.less
+++ b/less/mixins/branding.less
@@ -238,26 +238,7 @@
 
 }
 
-// Define the CSS variables for a brand colour.
-// This can't be called from the top level like apply-brand,
-// because it isn't valid CSS. In those cases you can call
-// this inside :root or inside a class, depending on when
-// you want them to apply. Normally you'd want it to be applied
-// to root at least once so it applies to the page, but you could
-// then apply another colour to a class that you can then add
-// at any level within the page to switch colour scheme.
-.brand-css-variables(@colour) {
-  @colours: .calculate-brand-colours(@colour);
-
-  --w-ref-colors-primary: @colours[@primary];
-  --w-ref-colors-secondary: @colours[@secondary];
-
-  //// Colour pairings
-
-  // Primary colour background
-  --w-sys-colors-primary: var(--w-ref-colors-primary);
-  --w-sys-colors-primary-contrast: @colours[@primary-contrast]; // black or white
-
+.colour-css-variables(@name, @clazz, @colour) {
   // Set of tints of the primary colour.
   // Copying Bootstrap 5's 100-900 system.
   @scale-values:
@@ -278,9 +259,44 @@
     @mix-color: if(@step < 500, #ffffff, if(@step > 500, #000000, @colour));
     @final-color: if(@step = 500, @colour, mix(@mix-color, @colour, @percent));
 
-    --w-sys-colors-primary-@{step}: @final-color;
-    --w-sys-colors-primary-@{step}-contrast: #wcag.contrast(@final-color, white, @text-color)[];
+    --w-@{clazz}-colors-@{name}-@{step}: @final-color;
+    --w-@{clazz}-colors-@{name}-@{step}-contrast: #wcag.contrast(@final-color, white, @text-color)[];
   });
+}
+
+.colour-sys-aliases(@name) {
+  .id7-brand-@{name} {
+    each(range(1,9), {
+      @step: @value * 100;
+      // These are defined with interpolated strings because otherwise it can't find the variables @name or @step -
+      // seems to be resolved in Less 4.x which we're not currently on yet
+      --w-sys-colors-primary-@{step}: ~"var(--w-ref-colors-@{name}-@{step})";
+      --w-sys-colors-primary-@{step}-contrast: ~"var(--w-ref-colors-@{name}-@{step}-contrast)";
+    })
+  }
+}
+
+// Define the CSS variables for a brand colour.
+// This can't be called from the top level like apply-brand,
+// because it isn't valid CSS. In those cases you can call
+// this inside :root or inside a class, depending on when
+// you want them to apply. Normally you'd want it to be applied
+// to root at least once so it applies to the page, but you could
+// then apply another colour to a class that you can then add
+// at any level within the page to switch colour scheme.
+.brand-css-variables(@colour) {
+  @colours: .calculate-brand-colours(@colour);
+
+  --w-ref-colors-primary: @colours[@primary];
+  --w-ref-colors-secondary: @colours[@secondary];
+
+  //// Colour pairings
+
+  // Primary colour - alias to tint 500
+  --w-sys-colors-primary: var(--w-sys-colors-primary-500);
+  --w-sys-colors-primary-contrast: var(--w-sys-colors-primary-500-contrast);
+
+  .colour-css-variables(primary, sys, @colour);
 
   // Secondary colour background
   --w-sys-colors-secondary: @colours[@secondary];
@@ -291,9 +307,6 @@
   --w-sys-colors-white-accent: @colours[@white-emphasis];
   // Slightly deeper colour (or black again)
   --w-sys-colors-white-deepAccent: @colours[@white-deep-emphasis];
-
-  --w-sys-colors-pale: @colours[@pale];
-  --w-sys-colors-pale-accent: @colours[@pale-emphasis];
 
   // This grey doesn't depend on the brand colour
   // but the emphasis colour does - may as well keep

--- a/less/variables.less
+++ b/less/variables.less
@@ -43,15 +43,22 @@
 @id7-brand-blue: #41748D;
 @id7-brand-teal: #507F70;
 
-// A fixed set of colours for which we'll generate some CSS variables
-// wrapped in classes. Actual set WIP (awaiting new colour values)
-@id7-brand-colors: gold-bright, blue-bright, teal-bright;
-@id7-generate-colour-classes: false; // don't actually generate them right now
+// 2025 sherbert flavours
+@id7-brand-coral: #F1977F;
+@id7-brand-lavender: #A499F4;
+@id7-brand-paleblue: #6CB7FF;
+@id7-brand-yellow: #FEDE7B;
+@id7-brand-green: #51D7C1;
 
-// Green is no longer a colour in the brand palette, but keeping here
-// for backward compatibility. Could alias it to teal?
-@id7-brand-green: #0F4001;
-@id7-brand-green-bright: #7ecbb6;
+// A fixed set of colours for which we'll generate some CSS variables
+// wrapped in classes. These names reference id7-brand-* variables above
+@id7-brand-colors: coral, lavender, paleblue, yellow, green;
+@id7-generate-colour-classes: true;
+
+// Green briefly wasn't a colour in the official palette, but now there is one
+// (though it's basically turquoise). Keeping the old "Bright Green" definition
+// though aliased to the new one for maximum confusion
+@id7-brand-green-bright: @id7-brand-green;
 
 
 @id7-brand-default: @id7-brand-purple;

--- a/vitest/brand-colours.ts
+++ b/vitest/brand-colours.ts
@@ -24,7 +24,8 @@ const definitions = [
   { name: 'orange-bright', description: 'Bright Orange', expectFailure: true },
   { name: 'blue', description: 'Dark Blue' },
   { name: 'blue-bright', description: 'Bright Blue', expectFailure: true },
-  { name: 'green', description: 'Dark Green' },
+  // Green isn't really green anymore, almost turquoise, so we expect it to look bad
+  { name: 'green', description: 'Dark Green', expectFailure: true },
   { name: 'green-bright', description: 'Bright Green', expectFailure: true },
   { name: 'teal', description: 'Teal' },
   { name: 'teal-bright', description: 'Bright Teal', expectFailure: true },

--- a/vitest/less-functions.ts
+++ b/vitest/less-functions.ts
@@ -53,7 +53,7 @@ export function getValueFromAst(ast: CssAst, name: string): string {
 export function getValuesFromAst(ast: CssAst): Record<string, string> {
   const rules = ast.stylesheet.rules;
   if (rules.length !== 1) {
-    throw new Error('Expected one rule, got ' + rules.length);
+    throw new Error('Expected one rule, got ' + rules.length + ': ' + ast.stylesheet.rules);
   }
   const decs = rules[0].declarations;
   return Object.fromEntries(decs.map(d => [d.property, d.value]));

--- a/vitest/less-functions.ts
+++ b/vitest/less-functions.ts
@@ -53,7 +53,7 @@ export function getValueFromAst(ast: CssAst, name: string): string {
 export function getValuesFromAst(ast: CssAst): Record<string, string> {
   const rules = ast.stylesheet.rules;
   if (rules.length !== 1) {
-    throw new Error('Expected one rule, got ' + rules.length + ': ' + ast.stylesheet.rules);
+    throw new Error('Expected one rule, got ' + rules.length + ': ' + ast.stylesheet.rules.map(r => r.selectors));
   }
   const decs = rules[0].declarations;
   return Object.fromEntries(decs.map(d => [d.property, d.value]));


### PR DESCRIPTION


These shouldn't have any visual effect on existing content, but will define a set of CSS properties and classes to activate them.

Page elements can be designed using the nonspecific "primary" color tints and contrasting values - then by adding one of the id7-brand-COLOUR classes to any containing element, they will become tints of that colour.

Also a helper class called `.bg-primary-500` (and again for all the other tints) which just sets the background and color to that tint+contrast. Something you could fairly easily implement yourself but helpful to have a basic implementation around, though it currently doesn't play well with headings and links and things that set a brand colour.