### PR TITLE
ID-444 Fix 'run' task.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@universityofwarwick/id7",
-  "version": "2.10.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@universityofwarwick/id7",
-      "version": "2.10.0",
+      "version": "2.11.1",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",
@@ -61,7 +61,6 @@
         "purify-css": "1.2.5",
         "purifycss-webpack": "0.7.0",
         "qunit": "2.9.3",
-        "remove-files-webpack-plugin": "1.2.1",
         "sinon": "8.0.2",
         "svg-inline-loader": "0.8.0",
         "terser-webpack-plugin": "2.3.1",
@@ -2418,51 +2417,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sindresorhus/df": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@sindresorhus/df/node_modules/execa": {
-      "version": "0.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn-async": "^2.1.1",
-        "npm-run-path": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "path-key": "^1.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/@sindresorhus/df/node_modules/npm-run-path": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@sindresorhus/df/node_modules/path-key": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "1.7.0",
       "dev": true,
@@ -2516,21 +2470,8 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@stroncium/procfs": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "CC0-1.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/anymatch": {
-      "version": "1.3.1",
       "dev": true,
       "license": "MIT"
     },
@@ -2594,51 +2535,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/source-list-map": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/tapable": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uglify-js": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@types/webpack": {
-      "version": "4.41.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/anymatch": "*",
-        "@types/node": "*",
-        "@types/tapable": "*",
-        "@types/uglify-js": "*",
-        "@types/webpack-sources": "*",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@types/webpack-sources": {
-      "version": "0.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/source-list-map": "*",
-        "source-map": "^0.6.1"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -5032,29 +4932,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cp-file": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cp-file/node_modules/pify": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/create-ecdh": {
       "version": "4.0.3",
       "dev": true,
@@ -5102,15 +4979,6 @@
       },
       "engines": {
         "node": ">=4.8"
-      }
-    },
-    "node_modules/cross-spawn-async": {
-      "version": "2.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^4.0.0",
-        "which": "^1.2.8"
       }
     },
     "node_modules/crypto-browserify": {
@@ -8411,14 +8279,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-path-inside": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
       "dev": true,
@@ -10756,35 +10616,6 @@
         "decamelize": "^1.2.0"
       }
     },
-    "node_modules/mount-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/df": "^1.0.1",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mount-point/node_modules/@sindresorhus/df": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mount-point/node_modules/pify": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "dev": true,
@@ -10796,38 +10627,6 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
-      }
-    },
-    "node_modules/move-file": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cp-file": "^6.1.0",
-        "make-dir": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/move-file/node_modules/make-dir": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/move-file/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/ms": {
@@ -10893,11 +10692,6 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/nested-error-stacks": {
-      "version": "2.1.0",
       "dev": true,
       "license": "MIT"
     },
@@ -11422,14 +11216,6 @@
       "version": "0.3.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/os-locale": {
       "version": "2.1.0",
@@ -13155,18 +12941,6 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
-      }
-    },
-    "node_modules/remove-files-webpack-plugin": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/webpack": "^4.41.0",
-        "trash": "^6.1.1"
-      },
-      "peerDependencies": {
-        "webpack": ">=2.2.0"
       }
     },
     "node_modules/remove-trailing-separator": {
@@ -15187,52 +14961,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/trash": {
-      "version": "6.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stroncium/procfs": "^1.0.0",
-        "globby": "^7.1.1",
-        "is-path-inside": "^3.0.2",
-        "make-dir": "^3.0.0",
-        "move-file": "^1.1.0",
-        "p-map": "^3.0.0",
-        "p-try": "^2.2.0",
-        "uuid": "^3.3.2",
-        "xdg-trashdir": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/trash/node_modules/make-dir": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/trash/node_modules/p-try": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/trash/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/tryer": {
       "version": "1.0.1",
       "dev": true,
@@ -15615,17 +15343,6 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/user-home": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-homedir": "^1.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17206,40 +16923,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xdg-basedir": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-homedir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/xdg-trashdir": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/df": "^2.1.0",
-        "mount-point": "^3.0.0",
-        "pify": "^2.2.0",
-        "user-home": "^2.0.0",
-        "xdg-basedir": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/xdg-trashdir/node_modules/pify": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "test:karma": "karma start --reporters=junit,progress js/tests/karma.conf.js",
     "test:vitest": "vitest",
     "test": "npm-run-all test:karma test:vitest",
-    "start": "npm-run-all --parallel readme-md2html watch docs-watch docs-serve",
+    "start": "npm-run-all --serial readme-md2html docs-assets --parallel docs-watch docs-serve",
     "docs-assets": "NODE_ENV=development webpack --mode development --env.docs",
     "docs-watch": "NODE_ENV=development webpack --mode development --env.docs --watch",
     "docs-serve": "bundle exec jekyll serve",
     "docs-build": "bundle exec jekyll build",
     "readme-md2html": "marked README.md > docs/_includes/README.html",
-    "prepublishOnly": "rm -rf ./dist/ && npm run build"
+    "clean": "rm -rf ./dist/ ./docs/dist/",
+    "prepublishOnly": "npm-run-all clean build"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
@@ -69,7 +70,6 @@
     "purify-css": "1.2.5",
     "purifycss-webpack": "0.7.0",
     "qunit": "2.9.3",
-    "remove-files-webpack-plugin": "1.2.1",
     "sinon": "8.0.2",
     "svg-inline-loader": "0.8.0",
     "terser-webpack-plugin": "2.3.1",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import EventEmitter from 'events';
 import WebpackNotifierPlugin from 'webpack-notifier';
-import RemovePlugin from 'remove-files-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import { ProvidePlugin } from 'webpack';
 import ZipPlugin from 'zip-webpack-plugin';
@@ -53,27 +52,6 @@ const commonConfig = basePath => merge([
         $: 'jquery',
       }),
       new PlayFingerprintsPlugin(),
-      new RemovePlugin({
-        before: {
-          root: paths.ROOT,
-          allowRootAndOutside: true,
-          include: [basePath],
-          log: false,
-          trash: false,
-        },
-        after: {
-          root: paths.ROOT,
-          allowRootAndOutside: true,
-          test: [
-            {
-              folder: paths.ASSETS_CSS(basePath),
-              method: filePath => (new RegExp(/.*\.js.*$/, 'm').test(filePath)),
-            },
-          ],
-          log: false,
-          trash: false,
-        },
-      }),
     ]
   },
   tooling.lintJS(),


### PR DESCRIPTION
Now you can actually change things and they will rebuild without imagery randomly vanishing.

No need to run the regular watch task as we only need the docs-watch task here. Never liked the remove-files plugin which was the ultimate culprit, randomly removing assets on rebuild. Replaced with a simple clean task for when you need it. Could add a call to clean at the start of the run task if we were worried about confusing leftovers.

Tweaked the startup of the run task so it will build assets once first before starting Jekyll - otherwise the site immediately starts up with no assets available until they first build which is confusing.