### PR TITLE
SBTWO-12266 Link focus styles.

### DIFF
--- a/bootstrap/less/mixins/tab-focus.less
+++ b/bootstrap/less/mixins/tab-focus.less
@@ -1,9 +1,4 @@
-// WebKit-style focus
-
 .tab-focus() {
-  // WebKit-specific. Other browsers will keep their default outline style.
-  // (Initially tried to also force default via `outline: initial`,
-  // but that seems to erroneously remove the outline in Firefox altogether.)
-  outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;
+  // We've removed the old Webkit stuff from here - we've augmented it in accessibility.less
+  // to apply the common focus outline to all elements.
 }

--- a/less/accessibility.less
+++ b/less/accessibility.less
@@ -1,16 +1,26 @@
+:root {
+  --w-ref-focusOutline: @focus-outline;
+  --w-sys-focusOutline: var(--w-ref-focusOutline);
+}
+
 .id7-outline() {
-  outline: 3px solid @focus-outline;
+  outline: 3px solid var(--w-sys-focusOutline);
   color: #0b0c0c !important;
-  background-color: @focus-outline !important;
-  box-shadow: 0 -2px @focus-outline, 0 6px #0b0c0c;
+  background-color: var(--w-sys-focusOutline) !important;
+  box-shadow: 0 -2px var(--w-sys-focusOutline), 0 6px #0b0c0c;
   text-decoration: none !important;
   transition-duration: 0s;
 }
 
-// This overrides Bootstrap's own tab-focus mixin which is how it gets applied to most links
+// This augments Bootstrap's own tab-focus mixin which is how it gets applied to most links
+// (the aforementioned mixin has been emptied out so these should be the only rules)
 .tab-focus() {
   outline-offset: 0;
   .id7-outline();
+}
+
+a:focus img {
+  background-color: var(--w-sys-focusOutline)
 }
 
 a:focus .id7-notifications-badge .counter-value {


### PR DESCRIPTION
They were merging with the existing Bootstrap link focus styles, and that seems to be inconsistent about which order they will get merged in, so in some cases the Bootstrap rules were overriding the accessibility ones, and adding a default webkit focus ring colour.

Since this is our copy of Bootstrap we can luckily just clear all that out.