### PR TITLE
ID-462 Utility bar links too close to wordmark.

### DIFF
--- a/docs/_includes/getting-started/download.html
+++ b/docs/_includes/getting-started/download.html
@@ -12,7 +12,7 @@
   <div class="col-sm-6">
     <h3 id="download-source">Source code</h3>
 
-    <p>Source Less, JavaScript, and font files, along with our docs. <a href="#grunt">Requires a Less compiler and some setup.</a></p>
+    <p>Source Less, JavaScript, and font files, along with our docs. <a href="#webpack">Requires a Less compiler and some setup.</a></p>
 
     <p><a href="https://github.com/UniversityofWarwick/id7/archive/v{{ site.current_version }}.zip" class="btn btn-info btn-lg"><i class="fa fa-code"></i> Download source</a></p>
   </div>

--- a/less/masthead.less
+++ b/less/masthead.less
@@ -71,7 +71,8 @@
     }
     // New layout
     & when (@id7-gen-layout > 2024) {
-      padding: var(--w-ref-gridGutterWidth);
+      padding: calc(0.5 * var(--w-ref-gridGutterWidth));
+      margin: calc(0.5 * var(--w-ref-gridGutterWidth));
     }
     // New logo without new layout
     & when (@id7-gen-logos > 2024) and (@id7-gen-layout = 2024) {


### PR DESCRIPTION
Swap half the padding for margin. Still looks good, it's accessible, everyone's happy.

Also fix a link in the getting started guide.