### PR TITLE
ID-295 Match cells in a thead.

### DIFF
--- a/less/main-content/max-widths.less
+++ b/less/main-content/max-widths.less
@@ -39,10 +39,8 @@ img, audio {
 
 @media (max-width: (@grid-float-breakpoint - 1)) {
   table[role="presentation"] {
-    > tr > td,
-    > tr > th,
-    > tbody > tr > td,
-    > tbody > tr > th,  {
+    > :is(thead, tbody) > tr > :is(td, th),
+    > tr > :is(td, th) {
       display: block !important;
       padding-left: 0 !important;
       padding-right: 0 !important;


### PR DESCRIPTION
It's debatable how useful this is as it isn't very readable with all the headings stacked at the top, and I don't know why a presentation (i.e. non-data) table would have header cells. But I've done this fix as it completes what was an only partially implemented attempt at restacking cells on mobile.

If we wanted something that actually stacked and was readable we'd want some JS to copy the header cell text into a data attribute on each data cell, so that we could reference it in CSS. It's not directly doable with pure CSS,