### PR TITLE
ID-475 Darker black.

### DIFF
--- a/less/variables.less
+++ b/less/variables.less
@@ -117,7 +117,7 @@
 // FA path, used in the font-awesome LESS files
 @int-fa-font-path: '../fonts';
 @body-bg: transparent;
-@text-color: if((@id7-gen-colours = 2024), #202020, #212529);
+@text-color: if((@id7-gen-colours = 2024), #202020, #0c0c0c);
 @font-stack-lato: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
 @font-stack-nhg-fallbacks: Aptos, 'Helvetica Neue', Helvetica, 'SF Pro', 'Liberation Sans', sans-serif;

--- a/vitest/less-functions.test.ts
+++ b/vitest/less-functions.test.ts
@@ -4,7 +4,7 @@ import css from 'css';
 
 test('evaluateVariable', async () => {
   const textColor = await lessFunctions.evaluateVariable('text-color');
-  expect(textColor).toBe('#212529');
+  expect(textColor).toBe('#0c0c0c');
 });
 
 test('renderLessFiles', async () => {


### PR DESCRIPTION
Although it's never actually referenced in the brand portal section about colours, this is the colour of black used in the screenshots of example text, and it's the colour used by the DXP.

Doing a side by side comparison it's a really slight change to the darkness, which is good because people are less likely to complain, but it's apparently enough to get sufficient WCAG contrast for the purple tint that was failing.