### PR TITLE
ID-483 disable postcss-calc.

### DIFF
--- a/build-tooling/webpack.tooling.mjs
+++ b/build-tooling/webpack.tooling.mjs
@@ -144,6 +144,7 @@ export const minify = () => ({
             discardComments: {
               removeAll: true,
             },
+            calc: false,
           }],
         },
       }),


### PR DESCRIPTION
We don't need the behaviour, so we can get rid of the warnings.

Ref: https://cssnano.github.io/cssnano/docs/optimisations/calc/