### PR TITLE
ID-484 Black headings all round.

### DIFF
--- a/bootstrap/less/type.less
+++ b/bootstrap/less/type.less
@@ -14,6 +14,7 @@
   font-family: var(--w-sys-fontFamily);
   font-weight: @headings-font-weight;
   line-height: @headings-line-height;
+  color: @headings-color-var;
 
   :is(small, .small) {
     font-weight: @main-font-weight;

--- a/less/design-tokens/colors.less
+++ b/less/design-tokens/colors.less
@@ -1,6 +1,9 @@
 @import (reference) "../mixins/branding";
 @import (reference) "../variables";
 
+// Some longer fallback var expressions to keep together
+@headings-color-var: var(--w-sys-colors-heading, var(--w-sys-colors-fg));
+
 :root {
   /* Reference tokens (don't use directly) */
   --w-ref-colors-blackText: @text-color;
@@ -13,10 +16,15 @@
     /* Default system tokens. Can be overridden */
   --w-sys-colors-paleGrey-contrast: var(--w-ref-colors-blackText);
 
+  --w-sys-colors-bg: var(--w-sys-colors-page);
+  // We shouldn't ever need to override this - instead set the `color` property and
+  // let the `currentColor` value do its thing.
+  --w-sys-colors-fg: currentColor;
+
   & when (@id7-generate-ref-colours) {
     each(@id7-ref-colors, {
       @brand-color-var: "id7-brand-@{value}";
-      @brand-color: @@brand-color-var;   
+      @brand-color: @@brand-color-var;
         .generate-tint-variables(@value, ref, @brand-color);
     });
   }
@@ -52,8 +60,8 @@
 
 // System tokens
 // Tokens that refer to other tokens are defined here in the * selector
-// to ensure they are always recalculated. If they were defined in :root, 
-// they would only be calculated once and would not update when the 
+// to ensure they are always recalculated. If they were defined in :root,
+// they would only be calculated once and would not update when the
 // target tokens they refer to are updated.
 // Note that as these aliases are redefined in every element,
 // you can't replace the alias in a container as it will get squashed
@@ -62,11 +70,6 @@
   // Primary colour - alias to tint 500
   --w-sys-colors-primary: var(--w-sys-colors-primary-500);
   --w-sys-colors-primary-contrast: var(--w-sys-colors-primary-500-contrast);
-
-  --w-sys-colors-heading: if(@id7-gen-colours>2024,
-    var(--w-sys-colors-fg),
-    var(--w-sys-colors-white-accent)
-  );
 }
 
 // Utility classes for switching between light and dark backgrounds.
@@ -75,26 +78,25 @@
 .bg-black {
   // Updates some system rendered elements to look better on a dark background.
   color-scheme: dark;
+  color: var(--w-ref-colors-page-dark-contrast);
   --w-sys-colors-bg: var(--w-ref-colors-page-dark);
-  --w-sys-colors-fg: var(--w-ref-colors-page-dark-contrast);
   --w-sys-colors-link: var(--w-ref-colors-page-dark-contrast);
   --w-sys-colors-page-grey: #aaa;
 }
 
 :root, .bg-white {
+  color: var(--w-sys-colors-page-contrast);
   --w-sys-colors-bg: var(--w-sys-colors-page);
-  --w-sys-colors-fg: var(--w-sys-colors-page-contrast);
   --w-sys-colors-link: var(--w-sys-colors-page-accent);
 }
 
 .bg-grey {
+  color: var(--w-sys-colors-paleGrey-contrast);
   --w-sys-colors-bg: var(--w-sys-colors-paleGrey);
-  --w-sys-colors-fg: var(--w-sys-colors-paleGrey-contrast);
   --w-sys-colors-link: var(--w-sys-colors-paleGrey-accent);
 }
 
 .bg-white, .bg-black, .bg-grey {
-  color: var(--w-sys-colors-fg);
   background-color: var(--w-sys-colors-bg);
 }
 

--- a/less/main-content/box-styles.less
+++ b/less/main-content/box-styles.less
@@ -20,32 +20,25 @@
 
 .box1 {
   .bg-primary-tint(100);
-  background-color: var(--w-sys-colors-bg);
-  color: var(--w-sys-colors-fg);
 }
 
 .box2 {
   --w-sys-colors-bg: var(--w-sys-colors-paleGrey);
-  --w-sys-colors-fg: var(--w-sys-colors-paleGrey-contrast);
   --w-sys-colors-link: var(--w-sys-colors-paleGrey-accent);
+  color: var(--w-sys-colors-paleGrey-contrast);
   background-color: var(--w-sys-colors-bg);
-  color: var(--w-sys-colors-fg);
 }
 
 .box5 {
-  .bg-primary-tint(500); 
-  background-color: var(--w-sys-colors-bg);
-  color: var(--w-sys-colors-fg);
+  .bg-primary-tint(500);
 }
 
 .bg-primary-tint(@tint) {
   // Define these variables for use in containing elements.
+  color: ~"var(--w-sys-colors-primary-@{tint}-contrast)";
   --w-sys-colors-bg: ~"var(--w-sys-colors-primary-@{tint})";
-  --w-sys-colors-fg: ~"var(--w-sys-colors-primary-@{tint}-contrast)";
-  --w-sys-colors-heading: var(--w-sys-colors-fg);
-  --w-sys-colors-link: var(--w-sys-colors-fg);
+  --w-sys-colors-link: currentColor;
   background-color: var(--w-sys-colors-bg);
-  color:            var(--w-sys-colors-fg);
 }
 
 each(100 300 500 700 900, {

--- a/less/navigation.less
+++ b/less/navigation.less
@@ -25,21 +25,19 @@
   // to allow site.css branding to override
   :where(&) .navbar {
     background-color: var(--w-sys-colors-bg);
-    color: var(--w-sys-colors-fg);
-
     --primary-bg-hover: hsl(from var(--w-sys-colors-bg) h s calc(l - 8));
   }
   .navbar-primary {
     --w-sys-colors-bg: var(--primary-bg);
-    --w-sys-colors-fg: var(--primary-fg);
+    color: var(--primary-fg);
   }
   .navbar-secondary {
     --w-sys-colors-bg: var(--secondary-bg);
-    --w-sys-colors-fg: var(--secondary-fg);
+    color: var(--secondary-fg);
   }
   .navbar-tertiary {
     --w-sys-colors-bg: var(--tertiary-bg);
-    --w-sys-colors-fg: var(--tertiary-fg);
+    color: var(--tertiary-fg);
   }
 
   .navbar {
@@ -76,7 +74,7 @@
     font-size: var(--w-sys-fontSizeNav);
     border: 0;
     --w-sys-colors-bg: var(--primary-bg);
-    --w-sys-colors-fg: var(--primary-fg);
+    color: var(--primary-fg);
 
     // Override Bootstrap's default dropdown component
     --w-cmp-dropdown-bg: var(--primary-bg);
@@ -314,9 +312,8 @@
 
   .navbar-secondary .navbar-nav > li:first-child {
     --w-sys-colors-bg: var(--w-sys-colors-primary-500);
-    --w-sys-colors-fg: var(--w-sys-colors-primary-500-contrast);
     background-color: var(--w-sys-colors-bg);
-    color: var(--w-sys-colors-fg);
+    color: var(--w-sys-colors-primary-500-contrast);
   }
 
   &.affix + .id7-navigation-marker {


### PR DESCRIPTION
Also ended up refactoring and simplifying how heading and fg colours are handled.

Previously we'd set `--w-sys-colors-fg` to the same value as `color`. Instead now `--w-sys-colors-fg` is set exactly once, to `currentColor`. Where we want to change the foreground colour, we now just set `color`.

For headings, it's now initially unset and heading colour is set to `var(--w-sys-colors-heading, var(--w-sys-colors-fg))` so it will initially take the value of the fg color (which is `currentColor`), so headings will follow the colour of all other text by default, but can be easily overriden to something else.